### PR TITLE
Add __serialize/__unserialize

### DIFF
--- a/lib/Horde/Stream.php
+++ b/lib/Horde/Stream.php
@@ -600,21 +600,37 @@ class Horde_Stream implements Serializable
      */
     public function serialize()
     {
-        $this->_params['_pos'] = $this->pos();
-
-        return json_encode(array(
-            strval($this),
-            $this->_params
-        ));
+        return json_encode($this->__serialize());
     }
 
     /**
      */
     public function unserialize($data)
     {
-        $this->_init();
 
-        $data = json_decode($data, true);
+        $this->__unserialize(json_decode($data, true));
+    }
+
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        $this->_params['_pos'] = $this->pos();
+
+        return array(
+            strval($this),
+            $this->_params
+        );
+    }
+
+    /**
+     * @param array $data
+     * @return void
+     */
+    public function __unserialize($data)
+    {
+        $this->_init();
         $this->add($data[0]);
         $this->seek($data[1]['_pos'], false);
         unset($data[1]['_pos']);

--- a/lib/Horde/Stream/TempString.php
+++ b/lib/Horde/Stream/TempString.php
@@ -251,28 +251,42 @@ class Horde_Stream_TempString extends Horde_Stream_Temp
      */
     public function serialize()
     {
-        if ($this->_string) {
-            $data = array(
-                $this->_string,
-                $this->_params
-            );
-        } else {
-            $data = parent::serialize();
-        }
-
-        return serialize($data);
+        return serialize($this->__serialize());
     }
 
     /**
      */
     public function unserialize($data)
     {
-        $data = unserialize($data);
+        $this->__unserialize(unserialize($data));
+    }
+
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        if ($this->_string) {
+            return array(
+                $this->_string,
+                $this->_params
+            );
+        } else {
+            return parent::__serialize();
+        }
+    }
+
+    /**
+     * @param array $data
+     * @return void
+     */
+    public function __unserialize($data)
+    {
         if ($data[0] instanceof Horde_Stream_String) {
             $this->_string = $data[0];
             $this->_params = $data[1];
         } else {
-            parent::unserialize($data);
+            parent::__unserialize($data);
         }
     }
 


### PR DESCRIPTION
> As of PHP 8.1.0, a class which implements Serializable without also implementing [__serialize()](https://www.php.net/manual/en/language.oop5.magic.php#object.serialize) and [__unserialize()](https://www.php.net/manual/en/language.oop5.magic.php#object.unserialize) will generate a deprecation warning.