### PR TITLE
fix: backport community fix from bytestream fork

### DIFF
--- a/lib/Horde/Stream.php
+++ b/lib/Horde/Stream.php
@@ -590,7 +590,7 @@ class Horde_Stream implements Serializable
      */
     public function close()
     {
-        if ($this->stream) {
+        if (is_resource($this->stream)) {
             fclose($this->stream);
         }
     }


### PR DESCRIPTION
Original-Author: Richard Steinmetz <richard@steinmetz.cloud> (is_resource check before fclose, 98c1813)
